### PR TITLE
Step/Isopleth API and some fixes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0  # fetch the entire repo history, required to guarantee versioneer will pick up the tags
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.4
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           # PyPy wheels not allowed because SciPy (build requirement) is not available
           CIBW_BUILD: cp3*-*

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -72,7 +72,7 @@ jobs:
           path: dist
           merge-multiple: true  # download and extract all artifacts in the same directory
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.11
+      - uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
           user: __token__
           password: ${{ secrets.PYPI_PYCALPHAD_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,19 +63,20 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # upload to PyPI when a GitHub Release is created
-    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: artifact-*
           path: dist
           merge-multiple: true  # download and extract all artifacts in the same directory
-
-      - uses: pypa/gh-action-pypi-publish@v1.8.14
+      - name: PyPI - Upload Artifacts to PyPI (Production)
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+        if: github.event_name == 'release' && github.event.action == 'published'
+      - name: TestPyPI - Upload Artifacts
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+        if: github.event_name == 'push' && github.ref_name == 'develop'
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_PYCALPHAD_TOKEN }}
-          # To test, uncomment the following:
-          # password: ${{ secrets.TEST_PYPI_PYCALPHAD_TOKEN }}
-          # repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -72,7 +72,7 @@ jobs:
           path: dist
           merge-multiple: true  # download and extract all artifacts in the same directory
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.12
+      - uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           user: __token__
           password: ${{ secrets.PYPI_PYCALPHAD_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0  # fetch the entire repo history, required to guarantee versioneer will pick up the tags
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         env:
           # PyPy wheels not allowed because SciPy (build requirement) is not available
           CIBW_BUILD: cp3*-*

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,7 +43,7 @@ jobs:
           name: pycalphad-documentation
           path: pycalphad-docs-html
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v2.1
+        uses: nwtgck/actions-netlify@v3.0
         with:
           publish-dir: 'pycalphad-docs-html'
           production-branch: develop

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -466,9 +466,19 @@ class TCPrinter(object):
                     terms += ' + ' + adding_term
             return terms
         elif isinstance(expr, Mul):
-            terms = self._stringify_expr(expr.args[0])
-            for arg in expr.args[1:]:
-                terms += ' * ' + self._stringify_expr(arg)
+            #For cases like: A*(B+C) where an Add object is one of the arguments in Mul
+            #We want to explicitly add the parenthesis around Add(B,C)
+            #and save it to A*(B+C) rather than A*B+C
+            #For other types of expr, this shouldn't be an issue since:
+            #    Mul should not need extra parenthesis, e.g. A*(B*C) -> A*B*C
+            #    Pow will explicitly add parenthesis (in the next elif block)
+            #    Other functions such as Log, Sin, etc should
+            #        include the parenthesis when converting to string
+            
+            #All the arguments in Mul should be tested and they're all combined to a single expression by ' * '
+            #    So we could stringify each argument as a list and join them together is ' * '
+            term_list = ['(' + self._stringify_expr(arg) + ')' if isinstance(arg,Add) else self._stringify_expr(arg) for arg in expr.args]
+            terms = ' * '.join(term_list)
             return terms
         elif isinstance(expr, Pow):
             if expr.args[0] == E:

--- a/pycalphad/mapping/__init__.py
+++ b/pycalphad/mapping/__init__.py
@@ -1,1 +1,1 @@
-from .compat_api import binplot, ternplot
+from .compat_api import binplot, ternplot, stepplot, isoplethplot

--- a/pycalphad/mapping/compat_api.py
+++ b/pycalphad/mapping/compat_api.py
@@ -1,15 +1,17 @@
 from pycalphad import Database, variables as v
 from pycalphad.mapping.mapper import Mapper
-from pycalphad.mapping.starting_points import automatic_starting_points_from_axis_limits
+from pycalphad.mapping.starting_points import automatic_starting_points_from_axis_limits, _generate_fixed_variable_conditions
 import matplotlib.pyplot as plt
 from pycalphad.mapping.plotting import plot_map
 import numpy as np
 from pycalphad.core.utils import unpack_components, filter_phases
 from pycalphad.plot.utils import phase_legend
 from pycalphad.plot import triangular  # register triangular projection
+from .primitives import STATEVARS
+import copy
 
 
-def binplot(database, components, phases, conditions, plot_kwargs=None, **map_kwargs):
+def binplot(database, components, phases, conditions, plot_kwargs=None, verbose=False, **map_kwargs):
     """
     Calculate the binary isobaric phase diagram.
 
@@ -59,6 +61,7 @@ def binplot(database, components, phases, conditions, plot_kwargs=None, **map_kw
 
     eq_kwargs = map_kwargs.get("eq_kwargs", {})  # only used for start points, not in the mapping currently
     mapper = Mapper(database, components, phases, conditions)
+    mapper.strategy.verbose = verbose
     start_points, start_dir = automatic_starting_points_from_axis_limits(database, components, phases, conditions, **eq_kwargs)
     mapper.strategy.add_starting_points_with_axes(start_points, start_dir)
     mapper.do_map()
@@ -73,7 +76,7 @@ def binplot(database, components, phases, conditions, plot_kwargs=None, **map_kw
     return ax
 
 
-def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, **plot_kwargs):
+def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, verbose=False, **plot_kwargs):
     """
     Calculate the ternary isothermal, isobaric phase diagram.
     This function is a convenience wrapper around equilibrium() and eqplot().
@@ -118,6 +121,7 @@ def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, **plot_k
 
     phases = filter_phases(dbf, unpack_components(dbf, comps), phases)
     mapper = Mapper(dbf, comps, phases, conds)
+    mapper.strategy.verbose = verbose
     start_points, start_dir = automatic_starting_points_from_axis_limits(dbf, comps, phases, conds)
     mapper.strategy.add_starting_points_with_axes(start_points, start_dir)
     mapper.do_map()
@@ -128,5 +132,163 @@ def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, **plot_k
 
     legend_generator = plot_kwargs.get('legend_generator', phase_legend)
     plot_map(mapper, tielines=plot_kwargs.get("tielines", True), ax=ax, legend_generator=legend_generator)
+
+    return ax
+
+def isoplethplot(database, components, phases, conditions, plot_kwargs=None, verbose=False, **map_kwargs):
+    """
+    Calculates an isopleth phase diagram.
+    For now, we'll define isopleths as having 1 potential condition and 1 non-potential condition
+    TODO: 
+
+    This function is a convenience wrapper around map_binary() and plot_boundaries()
+
+    Parameters
+    ----------
+    database : Database
+        Thermodynamic database containing the relevant parameters.
+    components : Sequence[str]
+        Names of components to consider in the calculation.
+    phases : Sequence[str]
+        Names of phases to consider in the calculation.
+    conditions : Mapping[v.StateVariable, Union[float, Tuple[float, float, float]]]
+        Maps StateVariables to values and/or iterables of values.
+        For binplot only one changing composition and one potential coordinate each is supported.
+    eq_kwargs : dict, optional
+        Keyword arguments to use in equilibrium() within map_binary(). If
+        eq_kwargs is defined in map_kwargs, this argument takes precedence.
+    map_kwargs : dict, optional
+        Additional keyword arguments to map_binary().
+    plot_kwargs : dict, optional
+        Keyword arguments to plot_boundaries().
+
+    Returns
+    -------
+    Axes
+        Matplotlib Axes of the phase diagram
+
+    Examples
+    --------
+    None yet.
+    """
+    indep_comps = [key for key, value in conditions.items() if isinstance(key, v.MoleFraction) and len(np.atleast_1d(value)) > 1]
+    indep_pots = [key for key, value in conditions.items() if (type(key) is v.StateVariable) and len(np.atleast_1d(value)) > 1]
+    if (len(indep_comps) != 1) or (len(indep_pots) != 1):
+        raise ValueError('isoplethplot() requires exactly one composition coordinate and one potential coordinate')
+    # TODO: try to give full backwards compatible support for plot_kwargs and map_kwargs
+    # remaining plot_kwargs from pycalphad.plot.binary.plot.plot_boundaries:
+    # tieline_color=(0, 1, 0, 1)
+    # remaining map_kwargs from pycalphad.plot.binary.map.map_binary:
+    # calc_kwargs=None
+    plot_kwargs = plot_kwargs if plot_kwargs is not None else dict()
+
+    # TODO: filtering phases should be done by the mapper
+    phases = filter_phases(database, unpack_components(database, components), phases)
+
+    eq_kwargs = map_kwargs.get("eq_kwargs", {})  # only used for start points, not in the mapping currently
+
+    comp_offset = sum([conditions[v] for v in conditions if (not isinstance(conditions[v], tuple) and v not in STATEVARS)])
+    conditions[indep_comps[0]] = (conditions[indep_comps[0]][0], np.amin([conditions[indep_comps[0]][1], 1-comp_offset]), conditions[indep_comps[0]][2])
+    axis_cond_keys = [key for key, val in conditions.items() if isinstance(val, tuple)]
+    
+    mapper = Mapper(database, components, phases, conditions)
+    
+    #Do step mapping along edges of variables (starting point for step mapping will be halfway point)
+    half_conds = {axis_var: (conditions[axis_var][0]+conditions[axis_var][1])/2 for axis_var in axis_cond_keys}
+    step_conditions = []
+    for axis_var in axis_cond_keys:
+        edge_conditions = {key:val for key,val in conditions.items()}
+        edge_conditions[axis_var] = half_conds[axis_var]
+
+        other_var = axis_cond_keys[1-axis_cond_keys.index(axis_var)]
+        if axis_var in STATEVARS:
+            edge_conditions[other_var] = np.amax([1e-2, conditions[other_var][0]])
+            step_conditions.append((copy.copy(edge_conditions), axis_var))
+            edge_conditions[other_var] = np.amin([conditions[other_var][1], 1-comp_offset-1e-2])
+            step_conditions.append((copy.copy(edge_conditions), axis_var))
+        # else:
+        #     edge_conditions[other_var] = conditions[other_var][0]
+        #     step_conditions.append((copy.copy(edge_conditions), axis_var))
+        #     edge_conditions[other_var] = conditions[other_var][1]
+        #     step_conditions.append((copy.copy(edge_conditions), axis_var)) 
+    
+    mapper.strategy.verbose = verbose
+    for sc in step_conditions:
+        mapper.strategy.add_nodes_from_conditions(*sc)
+
+    mapper.do_map()
+
+    ax = plot_kwargs.get("ax")
+    if ax is None:
+        ax = plt.figure().gca()
+    legend_generator = plot_kwargs.get('legend_generator', phase_legend)
+    plot_map(mapper, ax=ax, legend_generator=legend_generator)
+    ax.grid(plot_kwargs.get("gridlines", False))
+
+    return ax
+
+def stepplot(database, components, phases, conditions, plot_kwargs=None, verbose=False, **map_kwargs):
+    """
+    Calculate the binary isobaric phase diagram.
+
+    This function is a convenience wrapper around map_binary() and plot_boundaries()
+
+    Parameters
+    ----------
+    database : Database
+        Thermodynamic database containing the relevant parameters.
+    components : Sequence[str]
+        Names of components to consider in the calculation.
+    phases : Sequence[str]
+        Names of phases to consider in the calculation.
+    conditions : Mapping[v.StateVariable, Union[float, Tuple[float, float, float]]]
+        Maps StateVariables to values and/or iterables of values.
+        For binplot only one changing composition and one potential coordinate each is supported.
+    eq_kwargs : dict, optional
+        Keyword arguments to use in equilibrium() within map_binary(). If
+        eq_kwargs is defined in map_kwargs, this argument takes precedence.
+    map_kwargs : dict, optional
+        Additional keyword arguments to map_binary().
+    plot_kwargs : dict, optional
+        Keyword arguments to plot_boundaries().
+
+    Returns
+    -------
+    Axes
+        Matplotlib Axes of the phase diagram
+
+    Examples
+    --------
+    None yet.
+    """
+    indep_vars = [key for key, value in conditions.items() if len(np.atleast_1d(value)) > 1]
+    if len(indep_vars) != 1:
+        raise ValueError('stepplot() requires exactly one coordinate')
+    # TODO: try to give full backwards compatible support for plot_kwargs and map_kwargs
+    # remaining plot_kwargs from pycalphad.plot.binary.plot.plot_boundaries:
+    # tieline_color=(0, 1, 0, 1)
+    # remaining map_kwargs from pycalphad.plot.binary.map.map_binary:
+    # calc_kwargs=None
+    plot_kwargs = plot_kwargs if plot_kwargs is not None else dict()
+
+    # TODO: filtering phases should be done by the mapper
+    phases = filter_phases(database, unpack_components(database, components), phases)
+
+    eq_kwargs = map_kwargs.get("eq_kwargs", {})  # only used for start points, not in the mapping currently
+    mapper = Mapper(database, components, phases, conditions)
+    mapper.strategy.verbose = verbose
+    start_conditions = {key:value for key,value in conditions.items()}
+    start_conditions[indep_vars[0]] = (conditions[indep_vars[0]][0] + conditions[indep_vars[0]][1]) / 2
+    mapper.strategy.add_nodes_from_conditions(start_conditions)
+    mapper.do_map()
+
+    ax = plot_kwargs.get("ax")
+    if ax is None:
+        ax = plt.figure().gca()
+    legend_generator = plot_kwargs.get('legend_generator', phase_legend)
+    plot_map(mapper, tielines=plot_kwargs.get("tielines", True), ax=ax, legend_generator=legend_generator)
+    ax.grid(plot_kwargs.get("gridlines", False))
+
+    ax.set_ylim(bottom=0)
 
     return ax

--- a/pycalphad/mapping/compat_api.py
+++ b/pycalphad/mapping/compat_api.py
@@ -2,7 +2,7 @@ from pycalphad import Database, variables as v
 from pycalphad.mapping.mapper import Mapper
 from pycalphad.mapping.starting_points import automatic_starting_points_from_axis_limits, _generate_fixed_variable_conditions
 import matplotlib.pyplot as plt
-from pycalphad.mapping.plotting import plot_map
+from pycalphad.mapping.plotting import plot_map, plot_2d
 import numpy as np
 from pycalphad.core.utils import unpack_components, filter_phases
 from pycalphad.plot.utils import phase_legend
@@ -131,7 +131,11 @@ def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, **plot_k
         fig, ax = plt.subplots(subplot_kw={'projection': "triangular"})
 
     legend_generator = plot_kwargs.get('legend_generator', phase_legend)
-    plot_map(mapper, tielines=plot_kwargs.get("tielines", True), ax=ax, legend_generator=legend_generator)
+    #plot_map(mapper, tielines=plot_kwargs.get("tielines", True), ax=ax, legend_generator=legend_generator)
+    ms = mapper.strategy
+    plot_2d(ms, x, y, ax, tielines = 1, legend_generator=legend_generator)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
 
     return ax
 

--- a/pycalphad/mapping/compat_api.py
+++ b/pycalphad/mapping/compat_api.py
@@ -11,7 +11,7 @@ from .primitives import STATEVARS
 import copy
 
 
-def binplot(database, components, phases, conditions, plot_kwargs=None, verbose=False, **map_kwargs):
+def binplot(database, components, phases, conditions, plot_kwargs=None, **map_kwargs):
     """
     Calculate the binary isobaric phase diagram.
 
@@ -61,7 +61,7 @@ def binplot(database, components, phases, conditions, plot_kwargs=None, verbose=
 
     eq_kwargs = map_kwargs.get("eq_kwargs", {})  # only used for start points, not in the mapping currently
     mapper = Mapper(database, components, phases, conditions)
-    mapper.strategy.verbose = verbose
+    mapper.strategy.verbose = map_kwargs.get('verbose', False)
     start_points, start_dir = automatic_starting_points_from_axis_limits(database, components, phases, conditions, **eq_kwargs)
     mapper.strategy.add_starting_points_with_axes(start_points, start_dir)
     mapper.do_map()
@@ -76,7 +76,7 @@ def binplot(database, components, phases, conditions, plot_kwargs=None, verbose=
     return ax
 
 
-def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, verbose=False, **plot_kwargs):
+def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, **plot_kwargs):
     """
     Calculate the ternary isothermal, isobaric phase diagram.
     This function is a convenience wrapper around equilibrium() and eqplot().
@@ -121,7 +121,7 @@ def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, verbose=
 
     phases = filter_phases(dbf, unpack_components(dbf, comps), phases)
     mapper = Mapper(dbf, comps, phases, conds)
-    mapper.strategy.verbose = verbose
+    mapper.strategy.verbose = eq_kwargs.get('verbose', False)
     start_points, start_dir = automatic_starting_points_from_axis_limits(dbf, comps, phases, conds)
     mapper.strategy.add_starting_points_with_axes(start_points, start_dir)
     mapper.do_map()
@@ -135,7 +135,7 @@ def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, verbose=
 
     return ax
 
-def isoplethplot(database, components, phases, conditions, plot_kwargs=None, verbose=False, **map_kwargs):
+def isoplethplot(database, components, phases, conditions, plot_kwargs=None, **map_kwargs):
     """
     Calculates an isopleth phase diagram.
     For now, we'll define isopleths as having 1 potential condition and 1 non-potential condition
@@ -212,7 +212,7 @@ def isoplethplot(database, components, phases, conditions, plot_kwargs=None, ver
         #     edge_conditions[other_var] = conditions[other_var][1]
         #     step_conditions.append((copy.copy(edge_conditions), axis_var)) 
     
-    mapper.strategy.verbose = verbose
+    mapper.strategy.verbose = map_kwargs.get('verbose', False)
     for sc in step_conditions:
         mapper.strategy.add_nodes_from_conditions(*sc)
 
@@ -227,7 +227,7 @@ def isoplethplot(database, components, phases, conditions, plot_kwargs=None, ver
 
     return ax
 
-def stepplot(database, components, phases, conditions, plot_kwargs=None, verbose=False, **map_kwargs):
+def stepplot(database, components, phases, conditions, plot_kwargs=None, **map_kwargs):
     """
     Calculate the binary isobaric phase diagram.
 
@@ -276,7 +276,7 @@ def stepplot(database, components, phases, conditions, plot_kwargs=None, verbose
 
     eq_kwargs = map_kwargs.get("eq_kwargs", {})  # only used for start points, not in the mapping currently
     mapper = Mapper(database, components, phases, conditions)
-    mapper.strategy.verbose = verbose
+    mapper.strategy.verbose = map_kwargs.get('verbose', False)
     start_conditions = {key:value for key,value in conditions.items()}
     start_conditions[indep_vars[0]] = (conditions[indep_vars[0]][0] + conditions[indep_vars[0]][1]) / 2
     mapper.strategy.add_nodes_from_conditions(start_conditions)

--- a/pycalphad/mapping/plotting.py
+++ b/pycalphad/mapping/plotting.py
@@ -65,7 +65,9 @@ def is_true_node(node: Point, mapper):
     #   It is a node in the sense that it defines the start of a zpf line
     #   However, it is also not a node in this sense where it doesn't represent an invariant
     #Since we store all the conditions in the node, we can check this by gibbs phase rule f = n+2-p-c = 0
-    f = len(mapper.elements)-1 + 2 - len(node.stable_composition_sets) - (2-mapper.num_potential_conditions)
+    num_non_va = len(set(mapper.elements)-{'VA'})
+    #f = len(mapper.elements)-1 + 2 - len(node.stable_composition_sets) - (2-mapper.num_potential_conditions)
+    f = num_non_va + 2 - len(node.stable_composition_sets) - (2-mapper.num_potential_conditions)
     return f == 0
 
 # Case for tie-lines in planes - plot lines between the composition at each stable composition sets

--- a/pycalphad/mapping/primitives.py
+++ b/pycalphad/mapping/primitives.py
@@ -20,13 +20,13 @@ class ExitHint(Enum):
     NO_EXITS = 1
     FORCE_ALL_EXITS = 2
 
-def _eq_compset(compset: CompositionSet, other: CompositionSet):
+def _eq_compset(compset: CompositionSet, other: CompositionSet, atol = CS_EQ_TOL):
     # Composition set equality
     if compset is other:
         return True
     if compset.phase_record.phase_name != other.phase_record.phase_name:
         return False
-    if np.allclose(compset.dof, other.dof, atol=CS_EQ_TOL):
+    if np.allclose(compset.dof, other.dof, atol=atol):
         return True
     return False
 

--- a/pycalphad/mapping/primitives.py
+++ b/pycalphad/mapping/primitives.py
@@ -94,8 +94,8 @@ class Point():
             return False
 
     def __str__(self):
-        output = str([c.phase_record.phase_name for c in self.fixed_composition_sets])
-        output += str([c.phase_record.phase_name for c in self.free_composition_sets])
+        output = 'Fixed: ' + str([c.phase_record.phase_name for c in self.fixed_composition_sets])
+        output += ', Free: ' + str([c.phase_record.phase_name for c in self.free_composition_sets])
         output += str(self.global_conditions)
         return output
 
@@ -139,8 +139,8 @@ class Node(Point):
         return (self.axis_var, self.axis_direction)
 
     def __str__(self):
-        output = str([c.phase_record.phase_name for c in self.fixed_composition_sets])
-        output += str([c.phase_record.phase_name for c in self.free_composition_sets])
+        output = 'Fixed: ' + str([c.phase_record.phase_name for c in self.fixed_composition_sets])
+        output += ', Free: ' + str([c.phase_record.phase_name for c in self.free_composition_sets])
         output += str(self.global_conditions)
         output += str([self.axis_var, self.axis_direction])
         return output

--- a/pycalphad/mapping/starting_points.py
+++ b/pycalphad/mapping/starting_points.py
@@ -11,7 +11,7 @@ from pycalphad.core.constants import MIN_SITE_FRACTION
 
 from .primitives import STATEVARS, Point, Direction
 
-from pycalphad.mapping.utils import _extract_point_from_dataset, _is_a_potential, _get_conditions_from_eq
+from pycalphad.mapping.utils import _extract_point_from_dataset, _is_a_potential, _get_conditions_from_eq, _sort_cs_by_what_to_fix
 
 def starting_point_from_equilibrium(dbf, comps, phases, conditions, condition_to_drop, **eq_kwargs):
     """
@@ -116,6 +116,13 @@ def _get_unique_starting_points_from_along_potential_axis(dbf, comps, models, eq
                 solver = Solver(remove_metastable=True)
                 result = solver.solve(solution_compsets, {str(ky): vl for ky, vl in sub_conds.items()})
                 if result.converged and len(solution_compsets) == 2:
+                    solution_compsets = _sort_cs_by_what_to_fix(dbf, comps, models, solution_compsets)
+                    solution_compsets[0].fixed = True
+                    solution_compsets[0].NP = 0
+                    for i in range(1, len(solution_compsets)):
+                        solution_compsets[i].fixed = False
+                        solution_compsets[i].NP = 1 / (len(solution_compsets)-1)
+
                     point.global_conditions[axis_var] = _get_value_for_var(cs_1, axis_var)
                     found_starting_points.append(point)
             except Exception as e:

--- a/pycalphad/mapping/utils.py
+++ b/pycalphad/mapping/utils.py
@@ -70,14 +70,11 @@ def _sort_cs_by_what_to_fix(dbf, comps, models, cs_list):
     for i in range(len(cs_list)):
         for j in range(i+1, len(cs_list)):
             if doo_list[j] > doo_list[i]:
-                temp_cs = cs_list[i]
-                cs_list[i] = cs_list[j]
-                cs_list[j] = temp_cs
+                cs_list[i], cs_list[j] = cs_list[j], cs_list[i]
             elif doo_list[i] == doo_list[j]:
                 if prod_list[j] < prod_list[i]:
-                    temp_cs = cs_list[i]
-                    cs_list[i] = cs_list[j]
-                    cs_list[j] = temp_cs
+                    cs_list[i], cs_list[j] = cs_list[j], cs_list[i]
+
     return cs_list
 
 

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -845,6 +845,39 @@ def test_tc_printer_exp():
     result = TCPrinter()._stringify_expr(test_expr)
     assert result == 'exp(-300 * T**(-1))'
 
+def test_tc_printer_nested_mul_add():
+    """
+    TCPrinter retains parenthesis around a nested Mul(...,Add(...)) expression
+    Ex. A*(B+C) should result in A*(B+C) instead of A*B+C
+    Also, it should not add unnecessary parenthesis, so: 
+        A*(B*C) should be A*B*C and
+        A*B**C should be A * B**(C) instead of A * (B**(C))
+    """
+    #Test that parenthesis are retained for Mul(A,Add(B,C))
+    test_expr = S('A*(B+C)')
+    result = TCPrinter()._stringify_expr(test_expr)
+    #Test for B+C or C+B since this seems to differ across different OS
+    assert result == 'A * (B + C)' or result == 'A * (C + B)'
+
+    #Test for Mul(Add(A,B),Add(C,D))
+    test_expr = S('(A+B)*(C+D)')
+    result = TCPrinter()._stringify_expr(test_expr)
+    assert ('(A + B)' in result or '(B + A)' in result) and ('(C + D)' in result or '(D + C)' in result)
+
+    #Test that the parenthesis are ignored for Mul(A,Mul(B,C))
+    test_expr = S('A*(B*C)')
+    result = TCPrinter()._stringify_expr(test_expr)
+    #Since the ordering seem to sometimes differ across different OS
+    #    this would result in 6 different combinations to test
+    #    so we'll just test that the parenthesis are removed
+    assert '(' not in result and ')' not in result
+
+    #Test that parenthesis are not added for Mul(A,Pow(B,C))
+    #    We want to avoid cases where something like A * T**(B) becomes A * (T**(B))
+    test_expr = S('A*B**(C)')
+    result = TCPrinter()._stringify_expr(test_expr)
+    assert result == 'A * B**(C)'
+
 
 @select_database("Al-Fe_sundman2009.tdb")
 def test_database_symmetry_options_are_generated(load_database):


### PR DESCRIPTION
Main changes
- Added stepplot and isoplethplot functions. These have the same API as the binplot.
- Stepping will automatically add new starting points if a zpf line ends prematurely to force the entire axis range to be mapped out
    - ZPF line can end prematurely if a) an exit from a node could not be found, b) equilibrium from a step did not converge and we've reached the minimum step size, c) global min detected but a new node could not be found, d) an erroneous equilibrium result was detected
    - A new starting point will be added slightly closer to the axis limit it was stepping towards
-  Checking for composition change after testing exit directions in temperature even if there are no viable exit directions in temperature. This seems to prevent edge cases where testing exits in composition with stoichiometric or near-stoichiometric phases would occur (when testing T failed) and lead to DLASCLS error
- Checking if two composition sets are equal in composition before calling the Solver, this prevents cases where we leave a miscbility gap during stepping and have the fixed CS be the same as the free CS, leading to the DLASCLS error

Current issues
- Mapper assumes it can always step along a ZPF line at least once. If it can't, then it determines that it cannot step in that direction. If two nodes are connected to each other by 2 equal composition sets (Al-Cu-Y system), then the mapper will be unable to find the second node as an exit from the first node. 
    - A workaround would possibly include trying to add a new node if a new global min is found during the exit strategy. However, this would require that we find the actual global min, since using the composition sets found from the global min check can easily result in metastable nodes as the starting points can be wrong
- During global min check, an artificial miscibility gap may be incorrectly detected (seems to be for the few cases where the chemical potential hyperplane has an error large than our tolerance of 1e-4 J), then the free and fixed CS will converge to the same composition, but the solver will be unable to remove one of them
    - One solution in the mapper would be to account for the error in the chemical potential hyperplane (although shifting it downwards doesn't seem to make much of a difference), and increasing the tolerance for a new phase to be stable risks nodes from being undetected
    - Might be an option to add the change in chemical potential as a convergence criteria for equilibrium (this seems to be mentioned in Figure 1 in the Sundman mapping paper). However, this could affect the solver performance if the convergence criteria is too tight.


Update:
- The artifical miscibility gap looks like it can come from two cases
  - A) as stated above, the chemical potential hyperplane can have a large error if its sensitive to site fractions
  - B) if a composition set is going from an disorder to ordered state without going through a two-phase region (e.g. BCC_B2 in Al-Fe), then the composition set can be stuck in the disordered configuration and an ordered configuration will be viewed as a miscibility gap (even though its at the same/similar composition)
  - Workaround for this is to compute equilibrium with the new composition set and the composition set with the same phase name (both will be free CS). If the miscibility gap doesn't exist, then the two CS will converge. If we have a case like BCC_B2 in Al-Fe, then the phase fraction of the CSs will switch to favor the new and lower energy CS.
- Other pathways for the DLASCLS error
  - A) When we find starting points at the edges of the axes, we set the starting variable to be the other variable that we're not stepping in (ex. if we're stepping along T at the composition ends, then the starting variable of a starting point will be composition). If the two-phase region going off a composition end point is "steep" (low solubility) in temperature, then testing direction along composition will fail - this is similar to an earlier problem where we try to step along composition on a line compound
    - Workaround right now is when finding a starting point along the temperature axis, we select which composition set to fix based off some heuristics (the fixed phase will either be the most ordered - intermetallics or line compounds - or closest to the composition end points - low solubility). The same heuristics are also used when finding starting points along composition axis.
  - B) If an metastable node is found and the ZPF lines from the metastable node is "steep" in temperature, then the error could occur when testing an exit along the composition axis (although the solution here is, of course, to avoid finding incorrect nodes).
  - C) If we're traversing a miscibility gap and we reach where the miscibility gap closes, then we get the issue of a fixed and free CS at the same composition. We do have checks to ensure the composition sets are far enough before computing equilibrium, but I'm guessing this is a case where the composition sets are far enough to pass those tests, but when solving, they converge to the same point